### PR TITLE
Add final changes before discussion

### DIFF
--- a/Trie.cpp
+++ b/Trie.cpp
@@ -92,22 +92,23 @@ bool Trie::search(const string word)
 void Trie::deleteAllNodes(nodePointer lastPrefixNode, short lastPrefixCharIndex, nodePointer lastNode, string word)
 {
     nodePointer prevPtr = lastPrefixNode, ptr = lastPrefixNode->children[word[lastPrefixCharIndex] - 'a'];
+    short ptrIndex = lastPrefixCharIndex;
     if (lastNode == lastPrefixNode)
         return;
     while (ptr != lastNode)
     {
         prevPtr = ptr;
-        ptr = prevPtr->children[word[++lastPrefixCharIndex] - 'a'];
+        ptr = prevPtr->children[word[++ptrIndex] - 'a'];
     }
     delete ptr;
-    prevPtr->children[word[lastPrefixCharIndex] - 'a'] = NULL;
+    prevPtr->children[word[ptrIndex] - 'a'] = NULL;
     deleteAllNodes(lastPrefixNode, lastPrefixCharIndex, prevPtr, word);
 }
 
 void Trie::deleteWord(const string word)
 {
     nodePointer ptr = root, lastPrefixNode = NULL;
-    short i, j, count = 0, lastPrefixCharIndex = (word[0] - 'a');
+    short i, j, count, lastPrefixCharIndex = (word[0] - 'a');
 
     for (j = 0; j < word.length(); j++)
     {
@@ -115,10 +116,11 @@ void Trie::deleteWord(const string word)
         {
             return;
         }
+        count = 0;
         for (i = 0; i < alphabet_size; i++)
             if (ptr->children[i])
                 count++;
-        if (count > 1)
+        if (count > 1 || ptr->isEndofWord)
         {
             lastPrefixNode = ptr;
             lastPrefixCharIndex = j;
@@ -126,22 +128,10 @@ void Trie::deleteWord(const string word)
         ptr = ptr->children[word[j] - 'a'];
     }
 
-    count = 0;
-    for (i = 0; i < alphabet_size; i++)
-    {
-        if (ptr->children[i])
-        {
-            count++;
-            break;
-        }
-    }
-
-    if (count)
+    if (!ptr->isLeaf())
         ptr->isEndofWord = false;
-    else if (lastPrefixNode)
-        deleteAllNodes(lastPrefixNode, lastPrefixCharIndex, ptr, word);
     else
-        deleteAllNodes(root, lastPrefixCharIndex, ptr, word);
+        deleteAllNodes(lastPrefixNode, lastPrefixCharIndex, ptr, word);
 }
 
 void Trie::displayReq(ostream &out) const

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@ int main()
     trie1.insert("alert");
 
     cout << "\n*** enter a value to be stored in trie1\n";
-    // cin >> trie1;
+    cin >> trie1;
 
     cout << "\n*** Print the Trie Trie1 using the print - Display Functions\n";
     cout << trie1;

--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,7 @@ int main()
     trie1.insert("yehia");
     trie1.insert("yellow");
     trie1.insert("geno");
+    trie1.insert("gen");
     trie1.insert("mark");
     trie1.insert("albert");
     trie1.insert("alert");
@@ -30,7 +31,7 @@ int main()
     cout << "ahmed: " << trie1.search("ahmed") << endl;
     cout << "hussein: " << trie1.search("hussien") << endl;
 
-    cout << "\n*** Deleting values from the Trie Trie1 using the deleteWord method\n";
+    cout << "\n*** Deleting geno, alert, doll from the Trie Trie1 using the deleteWord method\n";
     trie1.deleteWord("geno");
     trie1.deleteWord("alert");
     trie1.deleteWord("doll");


### PR DESCRIPTION
deleteWord Trie member method contained a bug where the lastPrefixNode was always assigned the n-1 node, where n is the the length of the word, so only the last node was deleted from the Trie.

Also, in deleteAllNodes method, I added a variable to change with the incrementing pointer, instead of incrementing the lastPrefixCharIndex, which should be left constant.